### PR TITLE
chore: migrate Claude Code config to AGENTS.md, remove claude-code plugins

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,8 +23,7 @@
           "ms-vscode-remote.remote-containers",
           "ms-vscode-remote.remote-wsl",
           "ms-toolsai.jupyter",
-          "ritwickdey.LiveServer",
-          "Anthropic.claude-code"
+          "ritwickdey.LiveServer"
         ],
         "settings": {
           "python.testing.pytestArgs": [ "pipeline" ],

--- a/frontend/.devcontainer/Dockerfile
+++ b/frontend/.devcontainer/Dockerfile
@@ -1,10 +1,6 @@
 # Use Node.js 22 LTS (matches your current version)
 FROM node:22-bookworm
 
-ARG CLAUDE_CODE_VERSION=latest
-
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
-
 # Install additional OS packages if needed
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \

--- a/frontend/.devcontainer/devcontainer.json
+++ b/frontend/.devcontainer/devcontainer.json
@@ -2,10 +2,7 @@
   "name": "Databearer Frontend - Eleventy",
   "build": {
     "dockerfile": "Dockerfile",
-    "context": "..",
-    "args": {
-      "CLAUDE_CODE_VERSION": "latest"
-    }
+    "context": ".."
   },
 
   // Features to add to the dev container
@@ -36,8 +33,7 @@
         "DavidAnson.vscode-markdownlint",
         "eamodio.gitlens",
         "christian-kohler.path-intellisense",
-        "wayou.vscode-todo-highlight",
-        "Anthropic.claude-code"
+        "wayou.vscode-todo-highlight"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "zsh",
@@ -79,9 +75,7 @@
 
   // Mount the local workspace folder
   "mounts": [
-    "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
-    "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
-    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
+    "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached"
   ],
 
   // Working directory

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to coding agents when working with the frontend in this repository.
 
 ## Project Overview
 

--- a/image-generation/.devcontainer/devcontainer.json
+++ b/image-generation/.devcontainer/devcontainer.json
@@ -19,8 +19,7 @@
           "ms-vscode-remote.remote-containers",
           "ms-vscode-remote.remote-wsl",
           "ms-toolsai.jupyter",
-          "ritwickdey.LiveServer",
-          "Anthropic.claude-code"
+          "ritwickdey.LiveServer"
         ],
         "settings": {
           "python.testing.pytestArgs": [ "tests" ],


### PR DESCRIPTION
## Summary

We no longer use Claude Code. This migrates the Claude-specific config to the tool-agnostic `AGENTS.md` convention and removes the Claude Code plugin/extension wiring.

## Changes

- **`frontend/CLAUDE.md` → `frontend/AGENTS.md`** (renamed via `git mv`, history preserved). Reworded the header to be agent-agnostic; all the frontend guidance (commands, chart pipeline, front matter, collections) is kept as-is.
- **Removed `pipeline/.claude/settings.local.json`** — Claude Code permission config (no guidance content to migrate; it was an untracked local-only file).
- **Devcontainers — removed the `Anthropic.claude-code` VS Code extension** from all three (`.devcontainer/`, `frontend/.devcontainer/`, `image-generation/.devcontainer/`).
- **`frontend/.devcontainer/Dockerfile`** — dropped `ARG CLAUDE_CODE_VERSION` and the `npm install -g @anthropic-ai/claude-code` step.
- **`frontend/.devcontainer/devcontainer.json`** — removed the now-empty `CLAUDE_CODE_VERSION` build arg and the two `claude-code-*` volume mounts (`/commandhistory`, `/home/node/.claude`).

## Verification

- No `claude` references remain in tracked files (`git grep -i claude` → none).
- All three `devcontainer.json` files validate (JSONC for the frontend one).

Config/devcontainer-only; no application code or build output changes.